### PR TITLE
fix: numbering missing in outline

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -133,16 +133,24 @@
       }
 
       let page = counter(page).display()
-      let chap = if current_chapter != none {
-        smallcaps(current_chapter.body)
-      }
-      let chap_num = if current_chapter != none [
-        chap. #numbering(current_chapter.numbering, ..counter(heading).at(current_chapter.location()))
-      ]
 
-      let sec_num = if current_sec != none [
-        sec. #numbering(current_sec.numbering, ..counter(heading).at(current_sec.location()))
-      ]
+      let chap = if current_chapter != none {
+          smallcaps(current_chapter.body)
+        }
+
+      let chap_num = if current_chapter != none and "numbering" in current_chapter.fields() and current_chapter.numbering != none [
+          chap. #numbering(
+            current_chapter.numbering,
+            ..counter(heading).at(current_chapter.location())
+          )
+        ]
+
+      let sec_num = if current_sec != none and "numbering" in current_sec.fields() and current_sec.numbering != none [
+          sec. #numbering(
+            current_sec.numbering,
+            ..counter(heading).at(current_sec.location())
+          )
+        ]
 
       set text(size: 9pt)
 


### PR DESCRIPTION
Fixes #1 

Adds checks before evaluating `numbering(...)` for chapter and section headers to ensure numbering metadata exists and is not `none`. Preserves existing behavior while preventing compiler failures in cases where numbering information is unavailable.